### PR TITLE
Corrigido a implementação do limit() na busca

### DIFF
--- a/src/Controller/EntradasController.php
+++ b/src/Controller/EntradasController.php
@@ -131,13 +131,16 @@ class EntradasController extends AppController
 
         $query = $this->Entradas
             ->find()
-            ->limit(10)
             ->select(['id','titulo']);
 
         $resultado = [];
         foreach($query as $entrada){
             if (str_contains(strtolower($entrada->tituloDescrip()), $pesquisa['stringBusca'])) {
                 $resultado[] = $entrada;
+            }
+
+            if (count($resultado) > 9) {
+                break;
             }
         }
 


### PR DESCRIPTION
* Link da issue discutindo a modificação:
* Descrição detalhada do que se trata a modificação:
Pelo fato da busca do sistema ter que trazer todos registro para memória e depois fazer a busca em memória, o limit não poderia estar no SQL que trás as informações do banco.