### PR TITLE
Corrigindo erro na manipução dos Events do Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,8 +55,8 @@
         "stan": "phpstan analyse",
         "test": "phpunit --colors=always",
         "minificar-assets": "Config\\Tools\\Minificador::executar",
-        "post-package-install": "Config\\Tools\\PreparaAssets::executar",
-        "post-package-update":  "Config\\Tools\\PreparaAssets::executar"
+        "post-package-install": "Config\\Tools\\PreparaAssets::postPackageInstall",
+        "post-package-update":  "Config\\Tools\\PreparaAssets::postPackageUpdate"
     },
     "prefer-stable": true,
     "config": {

--- a/config/Tools/PreparaAssets.php
+++ b/config/Tools/PreparaAssets.php
@@ -3,7 +3,7 @@
 namespace Config\Tools;
 
 use Composer\Installer\PackageEvent;
-
+use Composer\Script\Event;
 /**
  * Trabalha os arquivos que precisam estar corretamente armazenados na pasta webroot/
  *
@@ -29,22 +29,46 @@ class PreparaAssets
     ];
 
     /**
-     * Copia os arquivos CSS e JS do pacote instalado/atualizado para devida pasta dentro do webroot/
+     * Recebe o evento de que um pacote foi atualizado
      *
      * @access	static public
      * @param	Composer\Installer\PackageEvent $event
      * @return	void
      */
-    static public function executar(PackageEvent $event)
+    public static function postPackageUpdate(PackageEvent $event)
     {
-        $installedPackage = $event->getOperation()->getPackage();
+        $nomePacote = $event->getOperation()->getTargetPackage()->getName();
+        self::executar($nomePacote);
+    }
 
-        if ($installedPackage->getName() == 'twbs/bootstrap-icons') {
+    /**
+     * Recebe o evento de que um pacote foi instalado
+     *
+     * @access	static public
+     * @param	Composer\Installer\PackageEvent $event
+     * @return	void
+     */
+    public static function postPackageInstall(PackageEvent $event)
+    {
+        $nomePacote = $event->getOperation()->getPackage()->getName();
+        self::executar($nomePacote);
+    }
+
+    /**
+     * Copia os arquivos CSS e JS do pacote instalado/atualizado para devida pasta dentro do webroot/
+     *
+     * @access static public
+     * @param string $nomePacote
+     * @return	void
+     */
+    static public function executar(string $nomePacote)
+    {
+        if ($nomePacote == 'twbs/bootstrap-icons') {
             self::excluiArquivo(self::$cssDestinoBootstrapIcons);
             self::copiarArquivo(self::$cssOrigemBootstrapIcons, self::$cssDestinoBootstrapIcons);
         }
 
-        if ($installedPackage->getName() == 'twbs/bootstrap') {
+        if ($nomePacote == 'twbs/bootstrap') {
             /* Excluir arquivos */
             self::excluirMultiplosArquivo(self::$pathDestinoCSS, self::$fileDestinoBootstrapCSS);
             self::excluirMultiplosArquivo(self::$pathDestinoJS, self::$fileDestinoBootstrapJS);

--- a/config/Tools/PreparaAssets.php
+++ b/config/Tools/PreparaAssets.php
@@ -3,7 +3,6 @@
 namespace Config\Tools;
 
 use Composer\Installer\PackageEvent;
-use Composer\Script\Event;
 /**
  * Trabalha os arquivos que precisam estar corretamente armazenados na pasta webroot/
  *
@@ -55,7 +54,7 @@ class PreparaAssets
     }
 
     /**
-     * Copia os arquivos CSS e JS do pacote instalado/atualizado para devida pasta dentro do webroot/
+     * Copia os arquivos do pacote informado para a devida pasta
      *
      * @access static public
      * @param string $nomePacote


### PR DESCRIPTION
## Correção de BUG
Na PR #33 foi introduzido um Bug na manipulação do Event do Composer. 
No caso de um evento de atualização de pacote, o caminho para obter o nome do pacote é diferente de quando é um evento de instalação.

## Melhorias
- Separado os métodos por tipo de evento
