### PR TITLE
refactor:  Melhorias na detecção do ambiente de execução

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -66,13 +66,9 @@ require CAKE . 'functions.php';
  * for more information for recommended practices.
  *
  *
- * As informações contidas no arquivo config/.env serão carregadas se:
- * - A variável de ambiente APP_NAME não deve existir
- * - O arquivo .env deve existir
- *
- * Se as duas condições forem atendidas significa que estamos em ambiente de desenvolvimento.
+ * As informações contidas no arquivo config/.env serão carregadas se as condições abaixo forem atendidas
 */
-if (!env('APP_NAME') && file_exists(CONFIG . '.env')) {
+if (!env('SERVER_NAME') && file_exists(CONFIG . '.env')) {
     $dotenv = new \josegonzalez\Dotenv\Loader([CONFIG . '.env']);
     $dotenv->parse()
         ->skipExisting()

--- a/src/Application.php
+++ b/src/Application.php
@@ -68,7 +68,7 @@ class Application extends BaseApplication implements AuthenticationServiceProvid
         // ambiente default
         $ambienteCorrente = self::PRODUCAO;
 
-        if (Configure::read('debug')) {
+        if (Configure::read('debug') || !getenv('SERVER_NAME', true)) {
             $ambienteCorrente = self::DESENVOLVIMENTO;
         }
         /* Adicionar aqui mais validações de ambiente */

--- a/src/Console/Installer.php
+++ b/src/Console/Installer.php
@@ -20,6 +20,7 @@ if (!defined('STDIN')) {
     define('STDIN', fopen('php://stdin', 'r'));
 }
 
+use App\Application;
 use Cake\Codeception\Console\Installer as CodeceptionInstaller;
 use Cake\Utility\Security;
 use Composer\IO\IOInterface;
@@ -59,11 +60,12 @@ class Installer
 
         $rootDir = dirname(dirname(__DIR__));
 
-        static::createAppLocalConfig($rootDir, $io);
-        static::createWritableDirectories($rootDir, $io);
-
-        static::setFolderPermissions($rootDir, $io);
-        static::setSecuritySalt($rootDir, $io);
+        if (Application::isTheExecutionEnvironment(Application::DESENVOLVIMENTO)) {
+            static::createAppLocalConfig($rootDir, $io);
+            static::createWritableDirectories($rootDir, $io);
+            static::setFolderPermissions($rootDir, $io);
+            static::setSecuritySalt($rootDir, $io);
+        }
 
         if (class_exists(CodeceptionInstaller::class)) {
             CodeceptionInstaller::customizeCodeceptionBinary($event);


### PR DESCRIPTION
## O que foi feito?
* ajuste na verificação do ambiente de execução e melhorias no instalador
* Alterada a condição para carregar o arquivo .env, agora utilizando SERVER_NAME.
* Atualizada a lógica de definição do ambiente padrão, considerando a ausência de SERVER_NAME.
* Modificadas as chamadas no instalador para criar configurações locais e permissões apenas em ambiente de desenvolvimento.

Link da Issue discutindo a modificação:
