### PR TITLE
fix: correção na verificação da variável SERVER_NAME

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -71,7 +71,7 @@ class Application extends BaseApplication implements AuthenticationServiceProvid
         if (
             Configure::read('debug')
             || file_exists(CONFIG . '.env')
-            || !getenv('SERVER_NAME', true)
+            || !getenv('SERVER_NAME')
         ) {
             $ambienteCorrente = self::DESENVOLVIMENTO;
         }


### PR DESCRIPTION
## O que foi feito?

* Ajustada a condição de verificação da variável SERVER_NAME para não utilizar o segundo parâmetro na função getenv, garantindo a correta identificação do ambiente de desenvolvimento.


Link da Issue discutindo a modificação:
